### PR TITLE
repository: Add descr for yum repository.

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -38,6 +38,7 @@ class bareos::repository(
         }
         yumrepo { 'bareos':
           name     => 'bareos',
+          descr    => 'Bareos Repository',
           baseurl  => $location,
           gpgcheck => '1',
           gpgkey   => "${location}repodata/repomd.xml.key",


### PR DESCRIPTION
This fixes the warning message:
Repository 'bareos' is missing name in configuration, using id
on each invocation of yum.