### PR TITLE
Add parameter exec_option of prepare bareos director for mysql

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -12,7 +12,8 @@ class bareos::director(
   $service_name   = $::bareos::director_service_name,
   $service_ensure = $::bareos::service_ensure,
   $service_enable = $::bareos::service_enable,
-  $config_dir     = "${::bareos::config_dir}/bareos-dir.d"
+  $config_dir     = "${::bareos::config_dir}/bareos-dir.d",
+  $exec_option    = $::bareos::exec_option,
 ) inherits ::bareos {
   include ::bareos::director::director
 
@@ -61,7 +62,7 @@ class bareos::director(
   }
 
   File <| |> -> exec { 'bareos director init catalog':
-    command     => '/usr/lib/bareos/scripts/create_bareos_database && /usr/lib/bareos/scripts/make_bareos_tables && /usr/lib/bareos/scripts/grant_bareos_privileges',
+    command     => "/usr/lib/bareos/scripts/create_bareos_database ${exec_option} && /usr/lib/bareos/scripts/make_bareos_tables ${exec_option} && /usr/lib/bareos/scripts/grant_bareos_privileges ${exec_option}",
     notify      => Service[$::bareos::director::service_name],
     refreshonly => true,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class bareos (
   $package_ensure   = $::bareos::params::package_ensure,
   $service_ensure   = $::bareos::params::service_ensure,
   $service_enable   = $::bareos::params::service_enable,
+  $exec_option      = $::bareos::params::exec_option,
 
   $console_package_name  = $::bareos::params::console_package_name,
   $monitor_package_name  = $::bareos::params::monitor_package_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,4 +53,7 @@ class bareos::params {
   # webui
   $webui_package_name = 'bareos-webui'
   $webui_service_name = 'apache2'
+
+  # exec options
+  $exec_option = ''
 }


### PR DESCRIPTION
Fix fail of exec 'bareos director init catalog' if set mysql root password. Example error:
```
Notice: /Stage[main]/Bareos::Director/Exec[bareos director init catalog]/returns: Creating mysql database
Notice: /Stage[main]/Bareos::Director/Exec[bareos director init catalog]/returns: ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: NO)
Notice: /Stage[main]/Bareos::Director/Exec[bareos director init catalog]/returns: Creating of bareos_db database failed.
Error: /Stage[main]/Bareos::Director/Exec[bareos director init catalog]: Failed to call refresh: '/usr/lib/bareos/scripts/create_bareos_database && /usr/lib/bareos/scripts/make_bareos_tables && /usr/lib/bareos/scripts/grant_bareos_privileges' returned 1 instead of one of [0]
Error: /Stage[main]/Bareos::Director/Exec[bareos director init catalog]: '/usr/lib/bareos/scripts/create_bareos_database && /usr/lib/bareos/scripts/make_bareos_tables && /usr/lib/bareos/scripts/grant_bareos_privileges' returned 1 instead of one of [0]
```
The new parameter allows to work around this problem for mysql.
For example:
```
  class { '::bareos':
    exec_option => '--defaults-file=/root/.my.cnf',
  }
```
`/root/.my.cnf` - is default file settings of root connection from puppet module [puppetlabs-mysql](https://github.com/puppetlabs/puppetlabs-mysql/blob/master/templates/my.cnf.pass.erb)