### PR TITLE
Workaround duplicate configs on package upgrades

### DIFF
--- a/manifests/client/client.pp
+++ b/manifests/client/client.pp
@@ -451,7 +451,7 @@ class bareos::client::client (
     $_require_res_messages = undef
   }
 
-  file { "${::bareos::client::config_dir}/${_resource_dir}/${name_client}.conf":
+  file { "${::bareos::client::config_dir}/${_resource_dir}/bareos-fd.conf":
     ensure  => $ensure,
     mode    => $::bareos::file_mode,
     owner   => $::bareos::file_owner,

--- a/manifests/director/director.pp
+++ b/manifests/director/director.pp
@@ -467,7 +467,7 @@ class bareos::director::director (
     $_require_resource = undef
   }
 
-  file { "${::bareos::director::config_dir}/${_resource_dir}/${name_director}.conf":
+  file { "${::bareos::director::config_dir}/${_resource_dir}/bareos-dir.conf":
     ensure  => $ensure,
     mode    => $::bareos::file_mode,
     owner   => $::bareos::file_owner,

--- a/manifests/storage/storage.pp
+++ b/manifests/storage/storage.pp
@@ -501,7 +501,7 @@ class bareos::storage::storage (
     $_require_resource = undef
   }
 
-  file { "${::bareos::storage::config_dir}/${_resource_dir}/${name_storage}.conf":
+  file { "${::bareos::storage::config_dir}/${_resource_dir}/bareos-sd.conf":
     ensure  => $ensure,
     mode    => $::bareos::file_mode,
     owner   => $::bareos::file_owner,


### PR DESCRIPTION
The bareos package deploy default configs if they dont exist. This can
lead to conflicts with the config and the package fails to upgrade.
We just set the file names fix for those resources which are only
allowed to exist once.
Fix #25