### PR TITLE
Allow numbers in directive config keys

### DIFF
--- a/lib/puppet/parser/functions/bareos_settings.rb
+++ b/lib/puppet/parser/functions/bareos_settings.rb
@@ -15,7 +15,7 @@ module Puppet::Parser::Functions
         required = setting[3] # boolean, undef allowed or not
         indent = setting[4] || '  ' # Internally used, just for beatufying
 
-        raise 'Name of directive config key is invalid' unless directive =~ %r{^[a-zA-z ]+$}
+        raise 'Name of directive config key is invalid' unless directive =~ %r{^[a-zA-z0-9 ]+$}
 
         # check array if allowed
         values = if (%w[acl runscript].include?(type) || type =~ %r{[_-]list$}) && value_setting.is_a?(Array)


### PR DESCRIPTION
To be able to specify specific settings for ipv4 and ipv6 addresses numbers in config keys must be allowed