### PR TITLE
Update dependency on puppetlabs/apt

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "tags": ["bareos", "backup"],
   "dependencies": [
     {"name": "puppetlabs/stdlib","version_requirement":">= 4.0.0 < 5.0.0"},
-    {"name": "puppetlabs/apt", "version_requirement": ">=2.0.0 < 5.0.0"},
+    {"name": "puppetlabs/apt", "version_requirement": ">=2.0.0 < 7.0.0"},
     {"name": "puppetlabs/concat", "version_requirement": ">=2.0.0 < 5.0.0"}
   ],
   "requirements": [
@@ -24,7 +24,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
@@ -32,7 +33,8 @@
       "operatingsystemrelease": [
         "12.04",
         "14.04",
-        "16.04"
+        "16.04",
+        "18.04"
       ]
     },
     {


### PR DESCRIPTION
Breaking changes for `puppetlabs/apt` 5.0.0 was a deprecation of Debian 7;
for 6.0.0, it was removal of support for Puppet <= 4.7.

Since the `bareos` module itself is not affected by syntax changes, we can
leave the dependency on apt pretty wide so users can choose a version of
apt supported on their OS version.