### PR TITLE
Puppet6 compatible bareos_settings.rb

### DIFF
--- a/lib/puppet/parser/functions/bareos_settings.rb
+++ b/lib/puppet/parser/functions/bareos_settings.rb
@@ -130,7 +130,7 @@ module Puppet::Parser::Functions
           end
         end
       rescue => error
-        raise Puppet::ParseError, "bareos_parse_settings(): #{setting.inspect}: #{error}."
+        raise Puppet::ParseError, "bareos_settings(): #{setting.inspect}: #{error}."
       end
     end
 

--- a/lib/puppet/parser/functions/bareos_settings.rb
+++ b/lib/puppet/parser/functions/bareos_settings.rb
@@ -11,19 +11,19 @@ module Puppet::Parser::Functions
         raise 'Invalid or incomplete setting' unless setting.length > 2 && setting.is_a?(Array)
         value_setting = setting[0] # value for this setting
         directive = setting[1] # Directive Keyword of this setting
-        type = setting[2] # bareos variable type
+        dirty_type = setting[2] # bareos variable type
         required = setting[3] # boolean, undef allowed or not
         indent = setting[4] || '  ' # Internally used, just for beatufying
 
         raise 'Name of directive config key is invalid' unless directive =~ %r{^[a-zA-Z0-9 ]+$}
 
         # check array if allowed
-        values = if (%w[acl runscript].include?(type) || type =~ %r{[_-]list$}) && value_setting.is_a?(Array)
+        values = if (%w[acl runscript].include?(dirty_type) || dirty_type =~ %r{[_-]list$}) && value_setting.is_a?(Array)
                    value_setting
                  else
                    [value_setting]
                  end
-        type.gsub!(%r{([_-]list)$}, '')
+        type = dirty_type.gsub(%r{([_-]list)$}, '')
 
         values.each do |value|
           # ignore undef if not required


### PR DESCRIPTION
I read that the module is not yet marked Puppet 6 ready. I tried it anyway with our Puppet 6.2 setup and ran into the following error:

```
[...]
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, bareos_parse_settings(): ["testserver, "Name", "name", true]: can't modify frozen object. (file: /etc/puppetlabs/code/environments/testing/modules/external/bareos/manifests/client/client.pp, line: 402, column: 18) on node testserver
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
[...]
```

I had a look into the bareos_settings.rb and realized that it was the `gsub` on the `type` variable in line 26 that was causing the error. https://github.com/Project0/puppet-bareos/blob/master/lib/puppet/parser/functions/bareos_settings.rb#L26

I forked and wrote a workaround for this which can be seen in this PR. I'm totally new to ruby so I can't tell if there are better ways/styles to fix this but if the campatibility with Puppet 6 is desired I'd be happy to participate.
If this is somehow not mergable I need some input what to change.

Additionally I fixed the wrong function name in the error message.