### PR TITLE
Introduce manage_database flag

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -5,14 +5,15 @@
 # This class will be automatically included when a resource is defined.
 # It is not intended to be used directly by external resources like node definitions or other modules.
 class bareos::director(
-  $manage_service = $::bareos::manage_service,
-  $manage_package = $::bareos::manage_package,
-  $package_name   = $::bareos::director_package_name,
-  $package_ensure = $::bareos::package_ensure,
-  $service_name   = $::bareos::director_service_name,
-  $service_ensure = $::bareos::service_ensure,
-  $service_enable = $::bareos::service_enable,
-  $config_dir     = "${::bareos::config_dir}/bareos-dir.d"
+  $manage_service  = $::bareos::manage_service,
+  $manage_package  = $::bareos::manage_package,
+  $manage_database = $::bareos::manage_database,
+  $package_name    = $::bareos::director_package_name,
+  $package_ensure  = $::bareos::package_ensure,
+  $service_name    = $::bareos::director_service_name,
+  $service_ensure  = $::bareos::service_ensure,
+  $service_enable  = $::bareos::service_enable,
+  $config_dir      = "${::bareos::config_dir}/bareos-dir.d"
 ) inherits ::bareos {
   include ::bareos::director::director
 
@@ -60,9 +61,11 @@ class bareos::director(
     notify  => Service[$service_name],
   }
 
-  File <| |> -> exec { 'bareos director init catalog':
-    command     => '/usr/lib/bareos/scripts/create_bareos_database && /usr/lib/bareos/scripts/make_bareos_tables && /usr/lib/bareos/scripts/grant_bareos_privileges',
-    notify      => Service[$::bareos::director::service_name],
-    refreshonly => true,
+  if $manage_database {
+    File <| |> -> exec { 'bareos director init catalog':
+      command     => '/usr/lib/bareos/scripts/create_bareos_database && /usr/lib/bareos/scripts/make_bareos_tables && /usr/lib/bareos/scripts/grant_bareos_privileges',
+      notify      => Service[$::bareos::director::service_name],
+      refreshonly => true,
+    }
   }
 }

--- a/manifests/director/catalog.pp
+++ b/manifests/director/catalog.pp
@@ -186,7 +186,9 @@ define bareos::director::catalog (
     content => template('bareos/resource.erb'),
     notify  => [
       Service[$::bareos::director::service_name],
-      Exec['bareos director init catalog'],
     ]
+  }
+  if $::bareos::manage_database {
+    File["${::bareos::director::config_dir}/${_resource_dir}/${name}.conf"] ~> Exec['bareos director init catalog']
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class bareos (
   $manage_user      = $::bareos::params::manage_user,
   $manage_package   = $::bareos::params::manage_package,
   $manage_service   = $::bareos::params::manage_service,
+  $manage_database  = $::bareos::params::manage_database,
   $package_name     = $::bareos::params::package_name, # base/common package only
   $package_ensure   = $::bareos::params::package_ensure,
   $service_ensure   = $::bareos::params::service_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,7 @@ class bareos::params {
   # defaults for the different services and base/common package
   $manage_package = true
   $manage_service = true
+  $manage_database = true
   $package_ensure = present
   $service_ensure = running
   $service_enable = true


### PR DESCRIPTION
This may be used to skip database/table creation. This is needed because
the used commandline does not work correctly with PSQL if root
is not able to use psql.